### PR TITLE
fix: illegal input may cause segfault

### DIFF
--- a/serialize.c
+++ b/serialize.c
@@ -509,6 +509,9 @@ static void
 get_buffer(lua_State *L, struct read_block *rb, int len) {
 	char tmp[len];
 	char * p = rb_read(rb,tmp,len);
+	if (p == NULL) {
+		invalid_stream(L, rb);
+	}
 	lua_pushlstring(L,p,len);
 }
 


### PR DESCRIPTION
serialize.c:512 push `p` as a string to the stack, but it does not determine whether `p` is `NULL`. The following code will cause a segfault.

```lua
local serialize = require "serialize"

local bin = serialize.serialize_string("abc")
bin = string.char(7) .. bin:sub(2)
serialize.deseristring_string(bin) -- segfault
```